### PR TITLE
Fixed broken podspec for OS X

### DIFF
--- a/GBDeviceInfo.podspec
+++ b/GBDeviceInfo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'GBDeviceInfo'
-  s.version      = '2.2.5'
+  s.version      = '2.2.6'
   s.summary      = 'Detects the hardware, software and display of the current iOS or Mac OS X device at runtime.'
   s.author       = 'Luka Mirosevic'      
   s.homepage	 = 'https://github.com/lmirosevic/GBDeviceInfo'
@@ -9,5 +9,6 @@ Pod::Spec.new do |s|
   s.ios.source_files = 'GBDeviceInfo/*_iOS.{h,m}', 'GBDeviceInfo/GBDeviceInfo.h'
   s.osx.source_files = 'GBDeviceInfo/*_OSX.{h,m}', 'GBDeviceInfo/GBDeviceInfo.h'
   s.requires_arc = true
-  s.platform     = :ios, '5.0'
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.6'
 end


### PR DESCRIPTION
The previous commit with 
`s.platform     = :ios, '5.0'`
broke OS X support by implicitly removing it.
