### PR TITLE
Garbage value leads to malloc error in low end devices. Hence Initialisi...

### DIFF
--- a/GBDeviceInfo/GBDeviceInfo_Common.m
+++ b/GBDeviceInfo/GBDeviceInfo_Common.m
@@ -105,7 +105,7 @@ static NSString * const kHardwareL2CacheSizeKey =           @"hw.l2cachesize";
     const char *keyCString = [key UTF8String];
     CGFloat answerFloat = 0;
     
-    size_t length;
+    size_t length = 0;
     sysctlbyname(keyCString, NULL, &length, NULL, 0);
     if (length) {
         char *answerRaw = malloc(length * sizeof(char));


### PR DESCRIPTION
...ng with 0.