### PR TITLE
Fix iPhone 6s iPhone 6s Plus device ids

### DIFF
--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -186,11 +186,11 @@
                 // 6
                 @[@(7), @(2)]: @[@(GBDeviceModeliPhone6), @"iPhone 6", @(326)],
                 
-                // 6S Plus
-                @[@(8), @(1)]: @[@(GBDeviceModeliPhone6SPlus), @"iPhone 6S Plus", @(401)],
-                
                 // 6S
-                @[@(8), @(2)]: @[@(GBDeviceModeliPhone6S), @"iPhone 6S", @(326)],
+                @[@(8), @(1)]: @[@(GBDeviceModeliPhone6S), @"iPhone 6S", @(326)],
+                
+                // 6S Plus
+                @[@(8), @(2)]: @[@(GBDeviceModeliPhone6SPlus), @"iPhone 6S Plus", @(401)],
             },
             @"iPad": @{
                 // 1


### PR DESCRIPTION
Device ids for iPhone 6s and iPhone 6s Plus are inverted.
This pull request fixes the issue.