### PR TITLE
Adding support for iPhone SE and iPad Pro 9.7-Inch

### DIFF
--- a/GBDeviceInfo.podspec
+++ b/GBDeviceInfo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                      = 'GBDeviceInfo'
-  s.version                   = '4.0.0'
+  s.version                   = '4.1.0'
   s.summary                   = 'Detects the hardware, software and display of the current iOS or Mac OS X device at runtime.'
   s.author                    = 'Luka Mirosevic'      
   s.homepage                  = 'https://github.com/lmirosevic/GBDeviceInfo'

--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -191,6 +191,9 @@
                 
                 // 6s Plus
                 @[@8, @2]: @[@(GBDeviceModeliPhone6sPlus), @"iPhone 6s Plus", @(GBDeviceDisplay5p5Inch), @401],
+                
+                // SE
+                @[@8, @4]: @[@(GBDeviceModeliPhoneSE), @"iPhone SE", @(GBDeviceDisplay4Inch), @326],
             },
             @"iPad": @{
                 // 1

--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -248,8 +248,8 @@
                 @[@6, @8]: @[@(GBDeviceModeliPadPro12p9Inch), @"iPad Pro 12.9-inch", @(GBDeviceDisplay12p9Inch), @264],
                 
                 // Pro 9.7-inch
-                @[@6, @7]: @[@(GBDeviceModeliPadPro9p7Inch), @"iPad Pro 9.7-inch", @(GBDeviceDisplay9p7Inch), @264],
-                @[@6, @8]: @[@(GBDeviceModeliPadPro9p7Inch), @"iPad Pro 9.7-inch", @(GBDeviceDisplay9p7Inch), @264],
+                @[@6, @3]: @[@(GBDeviceModeliPadPro9p7Inch), @"iPad Pro 9.7-inch", @(GBDeviceDisplay9p7Inch), @264],
+                @[@6, @4]: @[@(GBDeviceModeliPadPro9p7Inch), @"iPad Pro 9.7-inch", @(GBDeviceDisplay9p7Inch), @264],
             },
             @"iPod": @{
                 // 1st Gen

--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -243,6 +243,10 @@
                 // Pro 12.9-inch
                 @[@6, @7]: @[@(GBDeviceModeliPadPro12p9Inch), @"iPad Pro 12.9-inch", @(GBDeviceDisplay12p9Inch), @264],
                 @[@6, @8]: @[@(GBDeviceModeliPadPro12p9Inch), @"iPad Pro 12.9-inch", @(GBDeviceDisplay12p9Inch), @264],
+                
+                // Pro 9.7-inch
+                @[@6, @7]: @[@(GBDeviceModeliPadPro9p7Inch), @"iPad Pro 9.7-inch", @(GBDeviceDisplay9p7Inch), @264],
+                @[@6, @8]: @[@(GBDeviceModeliPadPro9p7Inch), @"iPad Pro 9.7-inch", @(GBDeviceDisplay9p7Inch), @264],
             },
             @"iPod": @{
                 // 1st Gen

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ if (deviceInfo.family != GBDeviceFamilyiPad) {
 }
 
 //Screen type
-if (deviceInfo.display == GBDeviceDisplayiPhone47Inch) {
+if (deviceInfo.display == GBDeviceDisplayiPhone4p7Inch) {
     NSLog(@"4.7 Inch display");                                     // 4.7 Inch display
 }
 
@@ -167,6 +167,7 @@ iOS Device support
 * iPhone6Plus
 * iPhone6S
 * iPhone6SPlus
+* iPhoneSE
 * iPad1
 * iPad2
 * iPad3
@@ -176,12 +177,14 @@ iOS Device support
 * iPadMini3
 * iPadAir1
 * iPadAir2
-* iPadPro
+* iPadPro9p7Inch
+* iPadPro12p9Inch
 * iPod1
 * iPod2
 * iPod3
 * iPod4
 * iPod5
+* iPod6
 * iPhone Simulator
 * iPad Simulator
 


### PR DESCRIPTION
Adds support for the new devices. Not merging this immediately as I want to give it a few days to get reliable model identifiers.