### PR TITLE
Adding iPad 5 (2017 model) as ipad6,11 and ipad6,12

### DIFF
--- a/GBDeviceInfo/GBDeviceInfoTypes_iOS.h
+++ b/GBDeviceInfo/GBDeviceInfoTypes_iOS.h
@@ -48,6 +48,7 @@ typedef NS_ENUM(NSInteger, GBDeviceModel) {
     GBDeviceModeliPadAir2,
     GBDeviceModeliPadPro9p7Inch,
     GBDeviceModeliPadPro12p9Inch,
+    GBDeviceModeliPad5,
     GBDeviceModeliPod1,
     GBDeviceModeliPod2,
     GBDeviceModeliPod3,

--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -258,6 +258,12 @@
                 // Pro 9.7-inch
                 @[@6, @3]: @[@(GBDeviceModeliPadPro9p7Inch), @"iPad Pro 9.7-inch", @(GBDeviceDisplay9p7Inch), @264],
                 @[@6, @4]: @[@(GBDeviceModeliPadPro9p7Inch), @"iPad Pro 9.7-inch", @(GBDeviceDisplay9p7Inch), @264],
+                
+                // iPad 5th Gen, 2017
+                @[@6, @11]: @[@(GBDeviceModeliPad5), @"iPad 2017",
+                              @(GBDeviceDisplay9p7Inch), @264],
+                @[@6, @12]: @[@(GBDeviceModeliPad5), @"iPad 2017",
+                              @(GBDeviceDisplay9p7Inch), @264],
             },
             @"iPod": @{
                 // 1st Gen


### PR DESCRIPTION
Hello,

We're really dependent on your library and our users use new iPad so it just has to be added I believe.