### PR TITLE
Fixed issue where ipod7 was returning wrong model.

### DIFF
--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -342,7 +342,7 @@
                 @[@7, @1]: @[@(GBDeviceModeliPod6), @"iPod Touch 6", @(GBDeviceDisplay4Inch), @326],
                 
                 // 7th Gen
-                @[@9, @1]: @[@(GBDeviceModeliPod6), @"iPod Touch 7", @(GBDeviceDisplay4Inch), @326],
+                @[@9, @1]: @[@(GBDeviceModeliPod7), @"iPod Touch 7", @(GBDeviceDisplay4Inch), @326],
             },
         };
         


### PR DESCRIPTION
Hi,

I noticed that the wrong device model was being returned when running on an iPod 7th generation. It turns out therers a slight error in the `familyManifest` dictionary in the `GBDeviceInfo_iOS.m`.

Let me know if you need any more info.