### PR TITLE
Fixes iPadPro10p5Inch vs. iPadPro10p5Inch2 issue

### DIFF
--- a/GBDeviceInfo/GBDeviceInfoTypes_iOS.h
+++ b/GBDeviceInfo/GBDeviceInfoTypes_iOS.h
@@ -58,7 +58,6 @@ typedef NS_ENUM(NSInteger, GBDeviceModel) {
     GBDeviceModeliPadPro9p7Inch,
     GBDeviceModeliPadPro10p5Inch,
     GBDeviceModeliPadPro12p9Inch,
-    GBDeviceModeliPadPro10p5Inch2,
     GBDeviceModeliPadPro12p9Inch2,
     GBDeviceModeliPadPro11p,
     GBDeviceModeliPadPro11p1TB,

--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -299,8 +299,8 @@
                 @[@7, @2]: @[@(GBDeviceModeliPadPro12p9Inch2), @"iPad Pro 12.9-inch 2017", @(GBDeviceDisplay12p9Inch), @264],
                 
                 // Pro 10.5-inch, 2017
-                @[@7, @3]: @[@(GBDeviceModeliPadPro10p5Inch2), @"iPad Pro 10.5-inch 2017", @(GBDeviceDisplay10p5Inch), @264],
-                @[@7, @4]: @[@(GBDeviceModeliPadPro10p5Inch2), @"iPad Pro 10.5-inch 2017", @(GBDeviceDisplay10p5Inch), @264],
+                @[@7, @3]: @[@(GBDeviceModeliPadPro10p5Inch), @"iPad Pro 10.5-inch 2017", @(GBDeviceDisplay10p5Inch), @264],
+                @[@7, @4]: @[@(GBDeviceModeliPadPro10p5Inch), @"iPad Pro 10.5-inch 2017", @(GBDeviceDisplay10p5Inch), @264],
                 
                 // iPad 6th Gen, 2018
                 @[@7, @5]: @[@(GBDeviceModeliPad6), @"iPad 2018", @(GBDeviceDisplay9p7Inch), @264],

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ iOS Device support
 * iPadAir2
 * iPadPro9p7Inch
 * iPadPro10p5Inch
-* iPadPro10p5Inch2
 * iPadPro12p9Inch
 * iPadPro12p9Inch2
 * iPod1


### PR DESCRIPTION
Hey Luka!

Thanks for creating such a great and useful library.

While building on top of it, I'd noticed that the 10.5 inch iPad Pro has two enum definitions (iPadPro10p5Inch and iPadPro10p5Inch2) despite only one 10.5 inch iPad Pro having been released. I think the confusion came from the 10.5 inch iPad Pro having been released alongside the second version of the 12.9 inch iPad Pro, replacing the 9.7 inch iPad Pro. You can see how the duplicate developed in PRs #75 and #67.

This PR unifies them as iPadPro10p5Inch, which I think best matches the device naming in the rest of the library.

Thanks for your consideration, and lmk if there's anything else you'd like out of the PR.

Best,
Chris