### PR TITLE
Fix capitalization of 'mini' in product names

### DIFF
--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -244,7 +244,7 @@
                 @[@12, @8]: @[@(GBDeviceModeliPhoneSE2), @"iPhone SE 2", @(GBDeviceDisplay4p7Inch), @326],
 
                 // 12 mini
-                @[@13, @1]: @[@(GBDeviceModeliPhone12Mini), @"iPhone 12 Mini", @(GBDeviceDisplay5p4Inch), @476],
+                @[@13, @1]: @[@(GBDeviceModeliPhone12Mini), @"iPhone 12 mini", @(GBDeviceDisplay5p4Inch), @476],
 
                 // 12
                 @[@13, @2]: @[@(GBDeviceModeliPhone12), @"iPhone 12", @(GBDeviceDisplay6p1Inch), @460],
@@ -265,10 +265,10 @@
                 @[@2, @3]: @[@(GBDeviceModeliPad2), @"iPad 2", @(GBDeviceDisplay9p7Inch), @132],
                 @[@2, @4]: @[@(GBDeviceModeliPad2), @"iPad 2", @(GBDeviceDisplay9p7Inch), @132],
 
-                // Mini
-                @[@2, @5]: @[@(GBDeviceModeliPadMini1), @"iPad Mini 1", @(GBDeviceDisplay7p9Inch), @163],
-                @[@2, @6]: @[@(GBDeviceModeliPadMini1), @"iPad Mini 1", @(GBDeviceDisplay7p9Inch), @163],
-                @[@2, @7]: @[@(GBDeviceModeliPadMini1), @"iPad Mini 1", @(GBDeviceDisplay7p9Inch), @163],
+                // mini
+                @[@2, @5]: @[@(GBDeviceModeliPadMini1), @"iPad mini 1", @(GBDeviceDisplay7p9Inch), @163],
+                @[@2, @6]: @[@(GBDeviceModeliPadMini1), @"iPad mini 1", @(GBDeviceDisplay7p9Inch), @163],
+                @[@2, @7]: @[@(GBDeviceModeliPadMini1), @"iPad mini 1", @(GBDeviceDisplay7p9Inch), @163],
 
                 // 3
                 @[@3, @1]: @[@(GBDeviceModeliPad3), @"iPad 3", @(GBDeviceDisplay9p7Inch), @264],
@@ -285,19 +285,19 @@
                 @[@4, @2]: @[@(GBDeviceModeliPadAir1), @"iPad Air 1", @(GBDeviceDisplay9p7Inch), @264],
                 @[@4, @3]: @[@(GBDeviceModeliPadAir1), @"iPad Air 1", @(GBDeviceDisplay9p7Inch), @264],
 
-                // Mini 2
-                @[@4, @4]: @[@(GBDeviceModeliPadMini2), @"iPad Mini 2", @(GBDeviceDisplay7p9Inch), @326],
-                @[@4, @5]: @[@(GBDeviceModeliPadMini2), @"iPad Mini 2", @(GBDeviceDisplay7p9Inch), @326],
-                @[@4, @6]: @[@(GBDeviceModeliPadMini2), @"iPad Mini 2", @(GBDeviceDisplay7p9Inch), @326],
+                // mini 2
+                @[@4, @4]: @[@(GBDeviceModeliPadMini2), @"iPad mini 2", @(GBDeviceDisplay7p9Inch), @326],
+                @[@4, @5]: @[@(GBDeviceModeliPadMini2), @"iPad mini 2", @(GBDeviceDisplay7p9Inch), @326],
+                @[@4, @6]: @[@(GBDeviceModeliPadMini2), @"iPad mini 2", @(GBDeviceDisplay7p9Inch), @326],
 
-                // Mini 3
-                @[@4, @7]: @[@(GBDeviceModeliPadMini3), @"iPad Mini 3", @(GBDeviceDisplay7p9Inch), @326],
-                @[@4, @8]: @[@(GBDeviceModeliPadMini3), @"iPad Mini 3", @(GBDeviceDisplay7p9Inch), @326],
-                @[@4, @9]: @[@(GBDeviceModeliPadMini3), @"iPad Mini 3", @(GBDeviceDisplay7p9Inch), @326],
+                // mini 3
+                @[@4, @7]: @[@(GBDeviceModeliPadMini3), @"iPad mini 3", @(GBDeviceDisplay7p9Inch), @326],
+                @[@4, @8]: @[@(GBDeviceModeliPadMini3), @"iPad mini 3", @(GBDeviceDisplay7p9Inch), @326],
+                @[@4, @9]: @[@(GBDeviceModeliPadMini3), @"iPad mini 3", @(GBDeviceDisplay7p9Inch), @326],
                 
-                // Mini 4
-                @[@5, @1]: @[@(GBDeviceModeliPadMini4), @"iPad Mini 4", @(GBDeviceDisplay7p9Inch), @326],
-                @[@5, @2]: @[@(GBDeviceModeliPadMini4), @"iPad Mini 4", @(GBDeviceDisplay7p9Inch), @326],
+                // mini 4
+                @[@5, @1]: @[@(GBDeviceModeliPadMini4), @"iPad mini 4", @(GBDeviceDisplay7p9Inch), @326],
+                @[@5, @2]: @[@(GBDeviceModeliPadMini4), @"iPad mini 4", @(GBDeviceDisplay7p9Inch), @326],
 
                 // Air 2
                 @[@5, @3]: @[@(GBDeviceModeliPadAir2), @"iPad Air 2", @(GBDeviceDisplay9p7Inch), @264],
@@ -355,9 +355,9 @@
                 @[@8, @11]: @[@(GBDeviceModeliPadPro12p9Inch4), @"iPad Pro 4rd Gen (12.9 inch, WiFi)", @(GBDeviceDisplay12p9Inch), @264],
                 @[@8, @12]: @[@(GBDeviceModeliPadPro12p9Inch4), @"iPad Pro 4rd Gen (12.9 inch, WiFi+Cellular)", @(GBDeviceDisplay12p9Inch), @264],
 
-                // Mini 5
-                @[@11, @1]: @[@(GBDeviceModeliPadMini5), @"iPad Mini 5", @(GBDeviceDisplay7p9Inch), @326],
-                @[@11, @2]: @[@(GBDeviceModeliPadMini5), @"iPad Mini 5", @(GBDeviceDisplay7p9Inch), @326],
+                // mini 5
+                @[@11, @1]: @[@(GBDeviceModeliPadMini5), @"iPad mini 5", @(GBDeviceDisplay7p9Inch), @326],
+                @[@11, @2]: @[@(GBDeviceModeliPadMini5), @"iPad mini 5", @(GBDeviceDisplay7p9Inch), @326],
                 
                 // Air 3
                 @[@11, @3]: @[@(GBDeviceModeliPadAir3), @"iPad Air 3", @(GBDeviceDisplay10p5Inch), @264],


### PR DESCRIPTION
As discussed here: https://github.com/lmirosevic/GBDeviceInfo/commit/18129e2b08044806b942a60a93ff443c2a6769c3

I only changed the strings, not the enums, as that looked weird and might break peoples builds.