### PR TITLE
Unify deviceVersion into common interface

### DIFF
--- a/GBDeviceInfo/GBDeviceInfo_Common.h
+++ b/GBDeviceInfo/GBDeviceInfo_Common.h
@@ -21,6 +21,11 @@
 @property (strong, atomic, readonly) NSString           *rawSystemInfoString;
 
 /**
+ The device version. e.g. {7, 2}.
+ */
+@property (assign, atomic, readonly) GBDeviceVersion    deviceVersion;
+
+/**
  The device family. e.g. GBDeviceFamilyiPhone.
  */
 @property (assign, atomic, readonly) GBDeviceFamily     family;

--- a/GBDeviceInfo/GBDeviceInfo_OSX.h
+++ b/GBDeviceInfo/GBDeviceInfo_OSX.h
@@ -31,11 +31,6 @@
 @property (strong, atomic, readonly) NSString           *nodeName;
 
 /**
- The device version. e.g. {13, 2}.
- */
-@property (assign, atomic, readonly) GBDeviceVersion    deviceVersion;
-
-/**
  System byte order, e.g. GBByteOrderLittleEndian.
  */
 @property (assign, atomic, readonly) GBByteOrder        systemByteOrder;

--- a/GBDeviceInfo/GBDeviceInfo_OSX.m
+++ b/GBDeviceInfo/GBDeviceInfo_OSX.m
@@ -34,7 +34,6 @@ static NSString * const kHardwareModelKey =                 @"hw.model";
 
 @interface GBDeviceInfo ()
 
-@property (assign, atomic, readwrite) GBDeviceVersion       deviceVersion;
 @property (assign, atomic, readwrite) GBByteOrder           systemByteOrder;
 @property (assign, atomic, readwrite) BOOL                  isMacAppStoreAvailable;
 @property (assign, atomic, readwrite) BOOL                  isIAPAvailable;

--- a/GBDeviceInfo/GBDeviceInfo_Subclass.h
+++ b/GBDeviceInfo/GBDeviceInfo_Subclass.h
@@ -9,10 +9,11 @@
 @interface GBDeviceInfo_Common ()
 
 @property (strong, atomic, readwrite) NSString          *rawSystemInfoString;
+@property (assign, atomic, readwrite) GBDeviceVersion   deviceVersion;
+@property (assign, atomic, readwrite) GBDeviceFamily    family;
 @property (assign, atomic, readwrite) GBCPUInfo         cpuInfo;
 @property (assign, atomic, readwrite) CGFloat           physicalMemory;
 @property (assign, atomic, readwrite) GBOSVersion       osVersion;
-@property (assign, atomic, readwrite) GBDeviceFamily    family;
 
 + (NSString *)_sysctlStringForKey:(NSString *)key;
 + (CGFloat)_sysctlCGFloatForKey:(NSString *)key;

--- a/GBDeviceInfo/GBDeviceInfo_iOS.h
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.h
@@ -24,15 +24,9 @@
 @interface GBDeviceInfo : GBDeviceInfo_Common
 
 /**
- The device version. e.g. {7, 2}.
- */
-@property (assign, atomic, readonly) GBDeviceVersion    deviceVersion;
-
-/**
  The human readable name for the device, e.g. "iPhone 6".
  */
 @property (strong, atomic, readonly) NSString           *modelString;
-
 
 /**
  The specific device model, e.g. GBDeviceModeliPhone6.

--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -33,7 +33,6 @@
 
 @interface GBDeviceInfo ()
 
-@property (assign, atomic, readwrite) GBDeviceVersion       deviceVersion;
 @property (strong, atomic, readwrite) NSString              *modelString;
 @property (assign, atomic, readwrite) GBDeviceModel         model;
 @property (assign, atomic, readwrite) GBDisplayInfo         displayInfo;


### PR DESCRIPTION
Hello, again, @lmirosevic!

While writing the last PR, I'd noticed that deviceVersion was duplicated across the iOS and macOS interfaces, despite being the same and the rest being shared. This unifies the two!

-Chris

P.S. I didn't do displayInfo, since it's actually fairly different under the hood and would have entailed lots more conditional code in GBDeviceInfo_Common.h
P.P.S If these get annoying, please lmk