### PR TITLE
Remove TARGET_IPHONE_SIMULATOR since it's deprecated.

### DIFF
--- a/GBDeviceInfo/GBDeviceInfo.h
+++ b/GBDeviceInfo/GBDeviceInfo.h
@@ -21,7 +21,7 @@
 
 /* iOS imports */
 
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_IPHONE
 
 #import "GBDeviceInfo_iOS.h"
 

--- a/GBDeviceInfo/GBDeviceInfo_iOS.m
+++ b/GBDeviceInfo/GBDeviceInfo_iOS.m
@@ -19,7 +19,7 @@
 
 #include <TargetConditionals.h>
 
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_IPHONE
 
 #import "GBDeviceInfo_iOS.h"
 
@@ -134,17 +134,15 @@
     GBDeviceDisplay display = GBDeviceDisplayUnknown;
     CGFloat pixelsPerInch = 0;
     
-    // Simulator
-    if (TARGET_IPHONE_SIMULATOR) {
+    #if TARGET_OS_SIMULATOR
         family = GBDeviceFamilySimulator;
         BOOL iPadScreen = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad;
         model = iPadScreen ? GBDeviceModelSimulatoriPad : GBDeviceModelSimulatoriPhone;
         modelString = iPadScreen ? @"iPad Simulator": @"iPhone Simulator";
         display = GBDeviceDisplayUnknown;
         pixelsPerInch = 0;
-    }
-    // Actual device
-    else {
+    #else
+        // Actual device
         GBDeviceVersion deviceVersion = [self _deviceVersion];
         NSString *systemInfoString = [self _rawSystemInfoString];
         
@@ -476,7 +474,7 @@
                 break;
             }
         }
-    }
+    #endif
     
     return @[@(family), @(model), modelString, @(display), @(pixelsPerInch)];
 }


### PR DESCRIPTION
From the commit message:

---

TARGET_OS_IPHONE includes simulator (and tvOS, watchOS, etc.), and TARGET_OS_SIMULATOR is the replacement, per TargetConditionals.h

---

Also, heads that you *might* want to change TARGET_OS_IPHONE to TARGET_OS_IOS if you don't intend the code to target, e.g., watchOS. That said, probably code targeting the other platforms like that would share almost all their implementation with the iOS implementation, which is why I left it as is. 