### PR TITLE
Cache cpuInfo on OSX, parallel to iOS

### DIFF
--- a/GBDeviceInfo/GBDeviceInfo_Common.m
+++ b/GBDeviceInfo/GBDeviceInfo_Common.m
@@ -129,7 +129,6 @@ static NSString * const kHardwareL2CacheSizeKey =           @"hw.l2cachesize";
     return answerFloat;
 }
 
-
 + (GBCPUInfo)_cpuInfo {
     return GBCPUInfoMake(
                          [self _sysctlCGFloatForKey:kHardwareCPUFrequencyKey] / 1000000000., //giga

--- a/GBDeviceInfo/GBDeviceInfo_OSX.m
+++ b/GBDeviceInfo/GBDeviceInfo_OSX.m
@@ -70,6 +70,7 @@ static NSString * const kHardwareModelKey =                 @"hw.model";
     if (self = [super init]) {
         self.rawSystemInfoString = [self.class _rawSystemInfoString];
         self.family = [self.class _deviceFamily];
+        self.cpuInfo = [self.class _cpuInfo];
         self.physicalMemory = [self.class _physicalMemory];
         self.systemByteOrder = [self.class _systemByteOrder];
         self.osVersion = [self.class _osVersion];
@@ -85,10 +86,6 @@ static NSString * const kHardwareModelKey =                 @"hw.model";
 
 - (NSString *)nodeName {
     return [self.class _nodeName];
-}
-
-- (GBCPUInfo)cpuInfo {
-    return [self.class _cpuInfo];
 }
 
 - (GBDisplayInfo)displayInfo {


### PR DESCRIPTION
Happened to notice that OSX wasn't caching cpu info, unlike iOS. I think this value should never change, [frequency being the nominal value](https://apple.stackexchange.com/questions/328965/is-there-a-way-to-see-current-cpu-frequency-in-macos-from-terminal-not-intel-po), so I edited things to make them parallel, and a little shorter.

More generally, I found myself thinking about the following change:
- Rather than precomputing everything and caching on init with a singleton, what about caching each property separately in its class method using static locals and a dispatch_once? 
  - Same thread safety and caching, but the work would be done lazily, and probably with less wrapping code.
  - You could maintain interface compatibility, I think, by having deviceInfo return self (the metaclass), but new users could skip the singleton pattern entirely.
Thoughts?