### PR TITLE
Add device families for June 2023 Macs

### DIFF
--- a/GBDeviceInfo/GBDeviceInfo_OSX.m
+++ b/GBDeviceInfo/GBDeviceInfo_OSX.m
@@ -160,10 +160,15 @@ static NSString * const kHardwareModelKey =                 @"hw.model";
             || [systemInfoString isEqualToString:@"Mac14,12"]) {
         return GBDeviceFamilyMacMini;
     }
-    else if ([systemInfoString hasPrefix:@"Mac13,"]) { // See https://support.apple.com/en-us/HT213073
+    else if (// See https://support.apple.com/en-us/HT213073
+             || [systemInfoString isEqualToString:@"Mac14,13"]
+             || [systemInfoString isEqualToString:@"Mac14,14"]
+             || [systemInfoString hasPrefix:@"Mac13,"]) {
         return GBDeviceFamilyMacStudio;
     }
-    else if ([systemInfoString hasPrefix:@"MacPro"]) {
+    else if ([systemInfoString hasPrefix:@"MacPro"]
+             // See https://support.apple.com/en-us/HT202888
+             || [systemInfoString isEqualToString:@"Mac14,8"]) {
         return GBDeviceFamilyMacPro;
     }
     else if ([systemInfoString hasPrefix:@"MacBookPro"]
@@ -177,6 +182,7 @@ static NSString * const kHardwareModelKey =                 @"hw.model";
     }
     else if ([systemInfoString hasPrefix:@"MacBookAir"]
              // See https://support.apple.com/en-us/HT201862
+             || [systemInfoString isEqualToString:@"Mac14,15"]
              || [systemInfoString isEqualToString:@"Mac14,2"]) {
         return GBDeviceFamilyMacBookAir;
     }


### PR DESCRIPTION
Hey, @lmirosevic.

Parallel to #144, this adds support for new Macs, which all, sadly, have ambiguous device family prefixes in their system info strings, as with #134 and #138.

Thanks for being great,
Chris

After merging, I'd still love your further thoughts on https://github.com/lmirosevic/GBDeviceInfo/pull/142#issuecomment-1427430620