### PR TITLE
Update podspec version to 7.3.0

### DIFF
--- a/GBDeviceInfo.podspec
+++ b/GBDeviceInfo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                      = 'GBDeviceInfo'
-  s.version                   = '7.2.0'
+  s.version                   = '7.3.0'
   s.summary                   = 'Detects the hardware, software and display of the current iOS or Mac OS X device at runtime.'
   s.author                    = 'Luka Mirosevic'      
   s.homepage                  = 'https://github.com/lmirosevic/GBDeviceInfo'


### PR DESCRIPTION
Hi, I guess the version in the .podspec file also need to be updated in order to push the changes to CocoaPods. I am asking anyone with the right permission to also add a tag `7.3.0` and push the new podspec to the CocoaPods trunk via `pod trunk push GBDeviceInfo.podspec`. Thanks!